### PR TITLE
Fix bug in `XBounds` calculation of minimum/maximum visible entry index.

### DIFF
--- a/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
@@ -217,7 +217,7 @@ open class ChartDataSet: ChartBaseDataSet
         rounding: ChartDataSetRounding) -> Int
     {
         var closest = partitioningIndex { $0.x >= xValue }
-        guard closest < endIndex else { return rounding == .closest ? (endIndex-1) : -1 }
+        guard closest < endIndex else { return [.down, .closest].contains(rounding) ? (endIndex-1) : -1 }
 
         var closestXValue = self[closest].x
 

--- a/Source/Charts/Renderers/BarLineScatterCandleBubbleRenderer.swift
+++ b/Source/Charts/Renderers/BarLineScatterCandleBubbleRenderer.swift
@@ -102,9 +102,15 @@ open class BarLineScatterCandleBubbleRenderer: NSObject, DataRenderer
             
             let low = chart.lowestVisibleX
             let high = chart.highestVisibleX
-            
-            let entryFrom = dataSet.entryForXValue(low, closestToY: .nan, rounding: .down)
-            let entryTo = dataSet.entryForXValue(high, closestToY: .nan, rounding: .up)
+
+            // First, try to find entries on the boundary of or outside of the visible range. Then, if there are none, try to find entries
+            // inside of the visible range.
+            //
+            // We want to allow and prioritize entries outside of the visible range because renderers may draw graphics in between entries.
+            // For example, a zoomed-in line graph should still show a line connecting the entry outside of the visible range with the entry
+            // inside of the visible range even if the line is only partially shown.
+            let entryFrom = dataSet.entryForXValue(low, closestToY: .nan, rounding: .down) ?? dataSet.entryForXValue(low, closestToY: .nan, rounding: .up)
+            let entryTo = dataSet.entryForXValue(high, closestToY: .nan, rounding: .up) ?? dataSet.entryForXValue(high, closestToY: .nan, rounding: .down)
             
             self.min = entryFrom == nil ? 0 : dataSet.entryIndex(entry: entryFrom!)
             self.max = entryTo == nil ? 0 : dataSet.entryIndex(entry: entryTo!)


### PR DESCRIPTION
Official Repo PR: https://github.com/danielgindi/Charts/pull/4839

`XBounds` looks for data entries on the boundary of or outside of the visible range. However, there may not be any such entries for a particular data set.

Imagine a chart with two data sets, one of which has a bigger range of x-values than the other. The chart’s zoomed-out visible range would be the range of the wider data set. When the renderer tries to render the narrower data set, it would fail to correctly calculate the starting and ending entry indices because the starting/ending entries are strictly inside of the visible range.

The fix is to add fallback logic to look for data entries inside of the visible range if the initial algorithm does not find anything.

The `XBounds` bug fix also requires a bug fix in `ChartDataSet`’s binary search algorithm.

### Issue Link :link:
<!-- What issue does this fix? If an issue doesn't exist, remove this section. -->

### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->

### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->